### PR TITLE
Fix minor bug reading input sample tsv in Snakefile_absolute

### DIFF
--- a/workflow/Snakefile_absolute
+++ b/workflow/Snakefile_absolute
@@ -9,7 +9,7 @@ import os
 
 configfile: "config/config.yaml"
 assert(isinstance(config["binSize"], int))
-df = pd.read_csv(config["samples"], delimiter='\t', dtype={"sample_name": str})
+df = pd.read_csv(config["samples"], delimiter='\t', dtype={"sample_name": str}, header = None)
 assert len(df.columns) == 1 or len(df.columns) == 3
 IMAGE = config["scAbsolute_img"]
 LOOKUP_PLOIDY = {}


### PR DESCRIPTION
First line in the tsv file containing the sample (formatted as highlighted in the examples) would be wrongly considered the header of the file with the prior version of Snakefile_absolute. Adding header = None to ensure the bam in the first line is not skipped